### PR TITLE
Let's provide friendly ID numbers

### DIFF
--- a/ExampleApi.sln
+++ b/ExampleApi.sln
@@ -18,6 +18,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Files", "Files", "{0368D731
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NumberBadger", "NumberBadger\NumberBadger.csproj", "{D12D264D-D860-4685-988A-CE01E79452F5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NumberBadger.Test", "NumberBadger.Test\NumberBadger.Test.csproj", "{667900E4-3C4A-45FC-9798-32295BD83C05}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +44,14 @@ Global
 		{F873CDB9-6413-4883-9DF6-D80EA143DEA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F873CDB9-6413-4883-9DF6-D80EA143DEA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F873CDB9-6413-4883-9DF6-D80EA143DEA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D12D264D-D860-4685-988A-CE01E79452F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D12D264D-D860-4685-988A-CE01E79452F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D12D264D-D860-4685-988A-CE01E79452F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D12D264D-D860-4685-988A-CE01E79452F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{667900E4-3C4A-45FC-9798-32295BD83C05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{667900E4-3C4A-45FC-9798-32295BD83C05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{667900E4-3C4A-45FC-9798-32295BD83C05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{667900E4-3C4A-45FC-9798-32295BD83C05}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NumberBadger.Test/ConversionTest.cs
+++ b/NumberBadger.Test/ConversionTest.cs
@@ -1,0 +1,49 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NumberBadger.Test;
+
+[TestClass]
+public class UnitTest1
+{
+    [TestMethod]
+    public void TestEmptyGuidParsing()
+    {
+        // Try once with a prefix
+        var originalData = Guid.Empty;
+        var badge = Badger.CreateBadge(originalData, "My");
+        Assert.AreEqual("My1111111111111111", badge);
+        var result = Badger.ParseGuid(badge, "My");
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(result.Value, originalData);
+        
+        // Now same thing without a prefix
+        badge = Badger.CreateBadge(originalData, null);
+        Assert.AreEqual("1111111111111111", badge);
+        result = Badger.ParseGuid(badge, null);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(result.Value, originalData);
+    }
+    
+    [TestMethod]
+    public void TestGuidFailures()
+    {
+        // Try a bad prefix
+        var badge = "Something that doesn't start with the correct prefix";
+        var result = Badger.ParseGuid(badge, "My");
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("The ID 'Something that doesn't start with the correct prefix' does not begin with the correct prefix 'My'.", result.Message);
+        
+        // Try something with a good prefix but bad data
+        badge = "My==========";
+        result = Badger.ParseGuid(badge, "My");
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("The ID 'My==========' is not a valid identity code.", result.Message);
+        
+        // Try an incomplete code - I've deleted half the data
+        badge = "My11111111";
+        result = Badger.ParseGuid(badge, "My");
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("The ID 'My11111111' is incomplete. Did you forget a few characters?", result.Message);
+
+    }
+}

--- a/NumberBadger.Test/ConversionTest.cs
+++ b/NumberBadger.Test/ConversionTest.cs
@@ -11,14 +11,14 @@ public class UnitTest1
         // Try once with a prefix
         var originalData = Guid.Empty;
         var badge = Badger.CreateBadge(originalData, "My");
-        Assert.AreEqual("My1111111111111111", badge);
+        Assert.AreEqual("Myrrrrrrrrrrrrrrrr", badge);
         var result = Badger.ParseGuid(badge, "My");
         Assert.IsTrue(result.Success);
         Assert.AreEqual(result.Value, originalData);
         
         // Now same thing without a prefix
         badge = Badger.CreateBadge(originalData, null);
-        Assert.AreEqual("1111111111111111", badge);
+        Assert.AreEqual("rrrrrrrrrrrrrrrr", badge);
         result = Badger.ParseGuid(badge, null);
         Assert.IsTrue(result.Success);
         Assert.AreEqual(result.Value, originalData);

--- a/NumberBadger.Test/GuidConversionTest.cs
+++ b/NumberBadger.Test/GuidConversionTest.cs
@@ -3,7 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace NumberBadger.Test;
 
 [TestClass]
-public class UnitTest1
+public class GuidConversionTest
 {
     [TestMethod]
     public void TestEmptyGuidParsing()
@@ -25,6 +25,20 @@ public class UnitTest1
     }
     
     [TestMethod]
+    public void TestRealGuids()
+    {
+        // Randomly generate a bunch of guids and test them
+        for (var i = 0; i < 1000; i++)
+        {
+            var originalData = Guid.NewGuid();
+            var badge = Badger.CreateBadge(originalData, "My");
+            var result = Badger.ParseGuid(badge, "My");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(result.Value, originalData);
+        }
+    }
+
+    [TestMethod]
     public void TestGuidFailures()
     {
         // Try a bad prefix
@@ -44,6 +58,5 @@ public class UnitTest1
         result = Badger.ParseGuid(badge, "My");
         Assert.IsFalse(result.Success);
         Assert.AreEqual("The ID 'My11111111' is incomplete. Did you forget a few characters?", result.Message);
-
     }
 }

--- a/NumberBadger.Test/Int64ConversionTest.cs
+++ b/NumberBadger.Test/Int64ConversionTest.cs
@@ -1,0 +1,63 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NumberBadger.Test;
+
+[TestClass]
+public class Int64ConversionTest
+{
+    [TestMethod]
+    public void TestEmptyInt64Parsing()
+    {
+        // Try once with a prefix
+        var originalData = 0L;
+        var badge = Badger.CreateBadge(originalData, "My");
+        Assert.AreEqual("Myrrrrrrrr", badge);
+        var result = Badger.ParseInt64(badge, "My");
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(result.Value, originalData);
+        
+        // Now same thing without a prefix
+        badge = Badger.CreateBadge(originalData, null);
+        Assert.AreEqual("rrrrrrrr", badge);
+        result = Badger.ParseInt64(badge, null);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(result.Value, originalData);
+    }
+    
+    [TestMethod]
+    public void TestRandomNumbers()
+    {
+        // Randomly generate a bunch of guids and test them
+        var rand = new Random();
+        for (var i = 0; i < 1000; i++)
+        {
+            var originalData = rand.NextInt64();
+            var badge = Badger.CreateBadge(originalData, "My");
+            var result = Badger.ParseInt64(badge, "My");
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(result.Value, originalData);
+        }
+    }
+
+    [TestMethod]
+    public void TestGuidFailures()
+    {
+        // Try a bad prefix
+        var badge = "Something that doesn't start with the correct prefix";
+        var result = Badger.ParseInt64(badge, "My");
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("The ID 'Something that doesn't start with the correct prefix' does not begin with the correct prefix 'My'.", result.Message);
+        
+        // Try something with a good prefix but bad data
+        badge = "My==========";
+        result = Badger.ParseInt64(badge, "My");
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("The ID 'My==========' is not a valid identity code.", result.Message);
+        
+        // Try an incomplete code - I've deleted half the data
+        badge = "My1111";
+        result = Badger.ParseInt64(badge, "My");
+        Assert.IsFalse(result.Success);
+        Assert.AreEqual("The ID 'My1111' is incomplete. Did you forget a few characters?", result.Message);
+    }
+}

--- a/NumberBadger.Test/NumberBadger.Test.csproj
+++ b/NumberBadger.Test/NumberBadger.Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NumberBadger\NumberBadger.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/NumberBadger/BadgerConverter.cs
+++ b/NumberBadger/BadgerConverter.cs
@@ -18,33 +18,99 @@ public static class Badger
         var encodedString = Base58.Ripple.Encode(value.ToByteArray());
         return $"{prefix}{encodedString}";
     }
-    
+
+    /// <summary>
+    /// Encodes an Int64 into a badge with an optional prefix
+    /// </summary>
+    /// <param name="value">The guid to encode</param>
+    /// <param name="prefix">A prefix to prepend to the badge</param>
+    /// <returns>The encoded badger string</returns>
+    public static string CreateBadge(Int64 value, string? prefix)
+    {
+        var bytes = BitConverter.GetBytes(value);
+        var encodedString = Base58.Ripple.Encode(bytes);
+        return $"{prefix}{encodedString}";
+    }
+
+    /// <summary>
+    /// Attempt to decode a badger string into an Int64
+    /// </summary>
+    /// <param name="badge">The badger string to attempt to decode</param>
+    /// <param name="expectedPrefix">The prefix of this table; if null, the raw string will be decoded</param>
+    /// <returns>The Int64 represented by the badge</returns>
+    public static BadgerResult<Int64> ParseInt64(string badge, string? expectedPrefix)
+    {
+        var bytesResult = ExtractBytes(badge, expectedPrefix, 8);
+        if (!bytesResult.Success || bytesResult.Value == null)
+        {
+            return new BadgerResult<Int64>()
+            {
+                Message = bytesResult.Message,
+                Success = false
+            };
+        }
+
+        return new BadgerResult<Int64>()
+        {
+            Success = true,
+            Value = BitConverter.ToInt64(bytesResult.Value)
+        };
+    }
+
     /// <summary>
     /// Attempt to decode a badger string into a GUID
     /// </summary>
     /// <param name="badge">The badger string to attempt to decode</param>
     /// <param name="expectedPrefix">The prefix of this table; if null, the raw string will be decoded</param>
-    /// <returns></returns>
+    /// <returns>The GUID represented by the badge</returns>
     public static BadgerResult<Guid> ParseGuid(string badge, string? expectedPrefix)
     {
+        var bytesResult = ExtractBytes(badge, expectedPrefix, 16);
+        if (!bytesResult.Success || bytesResult.Value == null)
+        {
+            return new BadgerResult<Guid>()
+            {
+                Message = bytesResult.Message,
+                Success = false
+            };
+        }
+
+        return new BadgerResult<Guid>()
+        {
+            Success = true,
+            Value = new Guid(bytesResult.Value)
+        };
+    }
+
+    /// <summary>
+    /// Attempt to convert an encoded badge into a byte array 
+    /// </summary>
+    /// <param name="badge">The original input string</param>
+    /// <param name="expectedPrefix">The expected table prefix</param>
+    /// <param name="numExpectedBytes">The number of bytes expected</param>
+    /// <returns></returns>
+    private static BadgerResult<byte[]> ExtractBytes(string badge, string? expectedPrefix, int numExpectedBytes)
+    {
         var codeString = badge;
-        
+
         // If we expect a prefix, make sure it exists
         if (expectedPrefix != null)
         {
             if (!badge.StartsWith(expectedPrefix))
             {
-                return new BadgerResult<Guid>()
                 {
-                    Message = $"The ID '{badge}' does not begin with the correct prefix '{expectedPrefix}'.",
-                    Success = false
-                };
+                    return new BadgerResult<byte[]>()
+                    {
+                        Message = $"The ID '{badge}' does not begin with the correct prefix '{expectedPrefix}'.",
+                        Success = false
+                    };
+                }
             }
 
             // Remove the prefix from the badge
             codeString = badge[expectedPrefix.Length..];
         }
-        
+
         // Convert the code portion into raw bytes
         var data = new byte[16];
         var success = false;
@@ -60,30 +126,34 @@ public static class Badger
         }
 
         // Detect non success
-        if (!success) {
-            return new BadgerResult<Guid>()
-            {
-                Message = $"The ID '{badge}' is not a valid identity code.",
-                Success = false
-            };
-
-        }
-
-        // Did we not get exactly 16 bytes?
-        if (numBytesWritten != 16)
+        if (!success)
         {
-            return new BadgerResult<Guid>()
             {
-                Message = $"The ID '{badge}' is incomplete. Did you forget a few characters?",
-                Success = false
-            };
+                return new BadgerResult<byte[]>()
+                {
+                    Message = $"The ID '{badge}' is not a valid identity code.",
+                    Success = false
+                };
+            }
         }
-        
-        // Looks like it parsed!
-        return new BadgerResult<Guid>()
+
+        // Did we not get exactly the correct number of bytes?
+        if (numBytesWritten != numExpectedBytes)
+        {
+            {
+                return new BadgerResult<byte[]>()
+                {
+                    Message = $"The ID '{badge}' is incomplete. Did you forget a few characters?",
+                    Success = false
+                };
+            }
+        }
+
+        // All is good
+        return new BadgerResult<byte[]>()
         {
             Success = true,
-            Value = new Guid(data)
+            Value = data
         };
     }
 }

--- a/NumberBadger/BadgerConverter.cs
+++ b/NumberBadger/BadgerConverter.cs
@@ -1,0 +1,89 @@
+﻿using SimpleBase;
+
+namespace NumberBadger;
+
+/// <summary>
+/// Represents a badger table definition
+/// </summary>
+public static class Badger
+{
+    /// <summary>
+    /// Encodes a GUID into a badge with an optional prefix
+    /// </summary>
+    /// <param name="value">The guid to encode</param>
+    /// <param name="prefix">A prefix to prepend to the badge</param>
+    /// <returns>The encoded badger string</returns>
+    public static string CreateBadge(Guid value, string? prefix)
+    {
+        var encodedString = Base58.Bitcoin.Encode(value.ToByteArray());
+        return $"{prefix}{encodedString}";
+    }
+    
+    /// <summary>
+    /// Attempt to decode a badger string into a GUID
+    /// </summary>
+    /// <param name="badge">The badger string to attempt to decode</param>
+    /// <param name="expectedPrefix">The prefix of this table; if null, the raw string will be decoded</param>
+    /// <returns></returns>
+    public static BadgerResult<Guid> ParseGuid(string badge, string? expectedPrefix)
+    {
+        var codeString = badge;
+        
+        // If we expect a prefix, make sure it exists
+        if (expectedPrefix != null)
+        {
+            if (!badge.StartsWith(expectedPrefix))
+            {
+                return new BadgerResult<Guid>()
+                {
+                    Message = $"The ID '{badge}' does not begin with the correct prefix '{expectedPrefix}'.",
+                    Success = false
+                };
+            }
+
+            // Remove the prefix from the badge
+            codeString = badge[expectedPrefix.Length..];
+        }
+        
+        // Convert the code portion into raw bytes
+        var data = new byte[16];
+        var success = false;
+        int numBytesWritten = 0;
+        try
+        {
+            success = Base58.Bitcoin.TryDecode(codeString, data, out numBytesWritten);
+        }
+        // Bummer! SimpleBase throws exceptions rather than just returning false
+        catch
+        {
+            success = false;
+        }
+
+        // Detect non success
+        if (!success) {
+            return new BadgerResult<Guid>()
+            {
+                Message = $"The ID '{badge}' is not a valid identity code.",
+                Success = false
+            };
+
+        }
+
+        // Did we not get exactly 16 bytes?
+        if (numBytesWritten != 16)
+        {
+            return new BadgerResult<Guid>()
+            {
+                Message = $"The ID '{badge}' is incomplete. Did you forget a few characters?",
+                Success = false
+            };
+        }
+        
+        // Looks like it parsed!
+        return new BadgerResult<Guid>()
+        {
+            Success = true,
+            Value = new Guid(data)
+        };
+    }
+}

--- a/NumberBadger/BadgerConverter.cs
+++ b/NumberBadger/BadgerConverter.cs
@@ -15,7 +15,7 @@ public static class Badger
     /// <returns>The encoded badger string</returns>
     public static string CreateBadge(Guid value, string? prefix)
     {
-        var encodedString = Base58.Bitcoin.Encode(value.ToByteArray());
+        var encodedString = Base58.Ripple.Encode(value.ToByteArray());
         return $"{prefix}{encodedString}";
     }
     
@@ -51,7 +51,7 @@ public static class Badger
         int numBytesWritten = 0;
         try
         {
-            success = Base58.Bitcoin.TryDecode(codeString, data, out numBytesWritten);
+            success = Base58.Ripple.TryDecode(codeString, data, out numBytesWritten);
         }
         // Bummer! SimpleBase throws exceptions rather than just returning false
         catch

--- a/NumberBadger/BadgerResult.cs
+++ b/NumberBadger/BadgerResult.cs
@@ -1,0 +1,19 @@
+﻿namespace NumberBadger;
+
+public class BadgerResult<T>
+{
+    /// <summary>
+    /// True if this badger conversion operation succeeded.
+    /// </summary>
+    public bool Success { get; set; }
+    
+    /// <summary>
+    /// If this badger conversion operation failed, this message explains why
+    /// </summary>
+    public string? Message { get; set; }
+    
+    /// <summary>
+    /// If the badger conversion succeeded, this is the value
+    /// </summary>
+    public T? Value { get; set; }
+}

--- a/NumberBadger/NumberBadger.csproj
+++ b/NumberBadger/NumberBadger.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="SimpleBase" Version="4.0.0" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Rather than encode ID numbers using standard GUID coding, let's offer something friendlier.

This PR uses Base58 Ripple encoding and has a few advantages:
* Supports and recognizes type prefixes, so you can tell what table an ID refers to 
* Doesn't use any non-alphanumeric characters
* If you double-click on it, you get the entire string